### PR TITLE
Remove "encoding-key", is no longer needed

### DIFF
--- a/res/elektroid.desktop
+++ b/res/elektroid.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Type=Application
-Encoding=UTF-8
 Name=Elektroid
 Comment=Sample transfer application for Elektron devices
 Comment[de]=Sample Transfer Anwendung für Elektron Instrumente


### PR DESCRIPTION
https://lintian.debian.org/tags/desktop-entry-contains-encoding-key.html