### PR TITLE
add libpulse-dev to Debian dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The package dependencies for Debian based distributions are:
 - libtool
 - autopoint
 - gettext
+- libpulse-dev
 
-You can easily install them by running `sudo apt install automake libasound2-dev libgtk-3-dev libpulse-dev libsndfile1-dev libsamplerate0-dev libtool autopoint gettext`.
+You can easily install them by running `sudo apt install automake libasound2-dev libgtk-3-dev libpulse-dev libsndfile1-dev libsamplerate0-dev libtool autopoint gettext libpulse-dev`.
 
 ## CLI
 


### PR DESCRIPTION
**Issue:**
```bash
$ ./configure
...
configure: error: Package requirements (libpulse >= 5.0) were not met:

No package 'libpulse' found
```

**Fix:**
```bash
$ sudo apt install libpulse-dev
```



**Debian Version:**
```bash
$ uname -a

Linux debian 4.19.0-8-amd64 #1 SMP Debian 4.19.98-1 (2020-01-26) x86_64 GNU/Linux

$ lsb_release -a
...
Description:	Debian GNU/Linux 10 (buster)
Release:	10
Codename:	buster
```