### PR TITLE
Fix build for GCC 10 and later

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -28,6 +28,8 @@
 #define REG_TYPE "emblem-music-symbolic"
 #define DIR_TYPE "folder-visiting-symbolic"
 
+int debug_level;
+
 static gchar
 connector_get_printable_char (gchar c)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -27,7 +27,7 @@
 
 #define debug_print(level, ...) if (level <= debug_level) fprintf(stderr, __VA_ARGS__)
 
-int debug_level;
+extern int debug_level;
 
 void print_ascii_msg (const GByteArray *);
 


### PR DESCRIPTION
As noted as https://gcc.gnu.org/gcc-10/changes.html#c the default for
GCC 10 is -fno-common which means that global variables must be declared
'extern' in headers and defined in exactly one source file.

This change has been successfully built for several distros at https://copr.fedorainfracloud.org/coprs/jwakely/elektroid/