### PR TITLE
Fix includes, fix build on musl libc

### DIFF
--- a/src/connector.c
+++ b/src/connector.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <endian.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <zlib.h>
 #include <libgen.h>
 #include "connector.h"

--- a/src/elektroid.c
+++ b/src/elektroid.c
@@ -20,6 +20,7 @@
 
 #include "../config.h"
 #include <limits.h>
+#include <locale.h>
 #include <gtk/gtk.h>
 #include <unistd.h>
 #include "connector.h"


### PR DESCRIPTION
Two small fixes to make elektroid build with musl libc.:
<sys/poll.h> is <poll.h> in POSIX, and setlocale requires <locale.h>.
