### PR TITLE
Fix "format not a string literal and no format arguments" compile error

### DIFF
--- a/src/elektroid.c
+++ b/src/elektroid.c
@@ -308,7 +308,7 @@ show_error_msg (const char *format, ...)
   dialog = gtk_message_dialog_new (GTK_WINDOW (main_window),
 				   GTK_DIALOG_DESTROY_WITH_PARENT |
 				   GTK_DIALOG_MODAL,
-				   GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, msg);
+				   GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s", msg);
   gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);
   g_free (msg);


### PR DESCRIPTION
I get an compile error building with debian sid:

> /usr/include/opus  -g -O2 -ffile-prefix-map=/build/elektroid-1.4=. -fstack-protector-strong -Wformat -Werror=format-security -c -o sample.o sample.c
>elektroid.c: In function 'show_error_msg':
>elektroid.c:221:8: error: format not a string literal and no format arguments [-Werror=format-security]
>  221 |        GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, msg);
>     |        ^~~~~~~~~~~~~~~~~
>gcc -DHAVE_CONFIG_H -I. -I..  -Wall -O3 -DDATADIR='"/usr/share"' -DLOCALEDIR=\""/usr/share/locale"\" -Wdate-time -D_FORTIFY_SOURCE=2 -I../src `/usr/bin/pkg-config --cflags alsa gtk+-3.0 libpulse libpulse-mainloop-glib zlib` -l
>/usr/include/opus  -g -O2 -ffile-prefix-map=/build/elektroid-1.4=. -fstack-protector-strong -Wformat -Werror=format-security -c -o utils.o utils.c
>gcc -DHAVE_CONFIG_H -I. -I..  -Wall -O3 -DDATADIR='"/usr/share"' -DLOCALEDIR=\""/usr/share/locale"\" -Wdate-time -D_FORTIFY_SOURCE=2 -I../src `/usr/bin/pkg-config --cflags alsa gtk+-3.0 libpulse libpulse-mainloop-glib zlib` -I
>/usr/include/opus  -g -O2 -ffile-prefix-map=/build/elektroid-1.4=. -fstack-protector-strong -Wformat -Werror=format-security -c -o notifier.o notifier.c
>elektroid.c: In function 'elektroid_tx_sysex_common':
>elektroid.c:667:7: warning: ignoring return value of 'fread' declared with attribute 'warn_unused_result' [-Wunused-result]
>  667 |       fread (sysex_transfer.data->data, size, 1, file);
>     |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>utils.c: In function 'get_local_startup_path':
>utils.c:213:4: warning: ignoring return value of 'realpath' declared with attribute 'warn_unused_result' [-Wunused-result]
>  213 |    realpath (local_dir, startup_path);
>      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`

this pull request fixes the build, but not sure if that is the real solution ;-)
elektroid 1.4 is reacting a bit slower than 1.3, but all works so far ive tested.