### PR TITLE
Fix "format not a string literal", fixes #75

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -201,7 +201,7 @@ backend_midi_handshake (struct backend *backend)
 		    backend->midi_info.version[1],
 		    backend->midi_info.version[2],
 		    backend->midi_info.version[3]);
-	  snprintf (backend->device_desc.name, LABEL_MAX,
+	  snprintf (backend->device_desc.name, LABEL_MAX, "%s",
 		    backend->device_name);
 	  debug_print (1, "Detected device: %s\n", backend->device_name);
 	}

--- a/src/connectors/efactor.c
+++ b/src/connectors/efactor.c
@@ -532,7 +532,7 @@ efactor_handshake (struct backend *backend)
 		    backend->midi_info.version[1],
 		    backend->midi_info.version[2],
 		    backend->midi_info.version[3]);
-	  snprintf (backend->device_desc.name, LABEL_MAX,
+	  snprintf (backend->device_desc.name, LABEL_MAX, "%s",
 		    backend->device_name);
 	  debug_print (1, "XML version:\n%s\n", &rx_msg->data[14]);
 	}


### PR DESCRIPTION
This fixes #75 the build error "format not a string literal" with 2.2. on debian (sid).