### PR TITLE
Add manifest for Flatpak build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ For Fedora, `sudo dnf install autoconf libtool alsa-lib-devel zlib-devel libzip-
 
 For Arch Linux, `sudo pacman -S base-devel autoconf libtool alsa-lib zlib libzip gtk3 libsndfile gettext libsamplerate pulseaudio json-glib` will install the build dependencies.
 
+To build a standalone Flatpak application, `flatpak-builder --user --install --force-clean flatpak/build flatpak/io.github.dagargo.Elektroid.yaml`
+and then you can use `flatpak run io.github.dagargo.Elektroid`
+(add `--cli` and extra arguments for the CLI utility).
+
 ### MIDI backend
 
 By default, Elektroid uses ALSA as the MIDI backend on Linux and RtMidi on other OSs. To use RtMidi on Linux, pass `RTMIDI=yes` to `./configure`. In this case, the RtMidi development package will be needed (`librtmidi-dev` on Debian).

--- a/flatpak/add-releases-to-appdata.patch
+++ b/flatpak/add-releases-to-appdata.patch
@@ -1,0 +1,31 @@
+commit 7b1f89174161b32616bf6218a437a0fe7c0e013d
+Author: Jonathan Wakely <jwakely@fedoraproject.org>
+Date:   Tue Mar 14 11:09:07 2023 +0000
+
+    Add <releases> to appdata
+    
+    Also remove stray non-ASCII character before <binary> element.
+
+diff --git a/res/elektroid.appdata.xml b/res/elektroid.appdata.xml
+index 7dc700e..e653a50 100644
+--- a/res/elektroid.appdata.xml
++++ b/res/elektroid.appdata.xml
+@@ -13,8 +13,17 @@
+  </description>
+  <launchable type="desktop-id">elektroid.desktop</launchable>
+  <provides>
+-​  <binary>elektroid</binary>
++  <binary>elektroid</binary>
+  </provides>
++ <releases>
++  <release version="2.4.1" date="2023-02-10" />
++  <release version="2.3" date="2022-12-04" />
++  <release version="2.2" date="2022-11-20" />
++  <release version="2.1" date="2022-06-03" />
++  <release version="2.0" date="2022-01-12" />
++  <release version="1.4" date="2021-07-18" />
++  <release version="1.3" date="2021-02-07" />
++ </releases>
+  <screenshots>
+   <screenshot type="default">
+    <image>https://screenshots.debian.net/screenshots/000/019/315/large.png</image>

--- a/flatpak/io.github.dagargo.Elektroid.yaml
+++ b/flatpak/io.github.dagargo.Elektroid.yaml
@@ -6,6 +6,10 @@ command: elektroid.sh
 finish-args:
   - "--socket=fallback-x11"
   - "--filesystem=home"
+rename-desktop-file: elektroid.desktop
+rename-appdata-file: elektroid.metadata.xml
+rename-icon: elektroid
+copy-icon: true
 modules:
   - name: libzip
     buildsystem: cmake-ninja

--- a/flatpak/io.github.dagargo.Elektroid.yaml
+++ b/flatpak/io.github.dagargo.Elektroid.yaml
@@ -10,6 +10,7 @@ rename-desktop-file: elektroid.desktop
 rename-appdata-file: elektroid.appdata.xml
 rename-icon: elektroid
 copy-icon: true
+separate-locales: false
 modules:
   - name: libzip
     buildsystem: cmake-ninja

--- a/flatpak/io.github.dagargo.Elektroid.yaml
+++ b/flatpak/io.github.dagargo.Elektroid.yaml
@@ -27,6 +27,10 @@ modules:
       - type: archive
         url: https://github.com/dagargo/elektroid/releases/download/2.4.1/elektroid-2.4.1.tar.gz
         sha256: 5690754d4cd73309cb6d6af898643f9e27c7cdaebba12747e5616c8548755cf2
+      # Add <releases> to elektroid-2.4.1/res/elektroid.appdata.xml
+      # This patch can be removed if elektroid-2.5 includes PR #95
+      - type: patch
+        path: add-releases-to-appdata.patch
   - name: elektroid.sh
     buildsystem: simple
     sources:

--- a/flatpak/io.github.dagargo.Elektroid.yaml
+++ b/flatpak/io.github.dagargo.Elektroid.yaml
@@ -6,6 +6,7 @@ command: elektroid.sh
 finish-args:
   - "--socket=fallback-x11"
   - "--filesystem=home"
+  - "--device=all"
 rename-desktop-file: elektroid.desktop
 rename-appdata-file: elektroid.appdata.xml
 rename-icon: elektroid

--- a/flatpak/io.github.dagargo.Elektroid.yaml
+++ b/flatpak/io.github.dagargo.Elektroid.yaml
@@ -7,7 +7,7 @@ finish-args:
   - "--socket=fallback-x11"
   - "--filesystem=home"
 rename-desktop-file: elektroid.desktop
-rename-appdata-file: elektroid.metadata.xml
+rename-appdata-file: elektroid.appdata.xml
 rename-icon: elektroid
 copy-icon: true
 modules:

--- a/flatpak/io.github.dagargo.Elektroid.yaml
+++ b/flatpak/io.github.dagargo.Elektroid.yaml
@@ -1,0 +1,34 @@
+id: io.github.dagargo.Elektroid
+runtime: org.gnome.Platform
+runtime-version: '43'
+sdk: org.gnome.Sdk
+command: elektroid.sh
+finish-args:
+  - "--socket=fallback-x11"
+  - "--filesystem=home"
+modules:
+  - name: libzip
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: https://libzip.org/download/libzip-1.9.2.tar.gz
+        sha256: fd6a7f745de3d69cf5603edc9cb33d2890f0198e415255d0987a0cf10d824c6f
+    # Disable installation of libzip tools in /app/bin:
+    config-opts: ['-DBUILD_TOOLS=OFF']
+  - name: elektroid
+    buildsystem: autotools
+    no-autogen: true
+    sources:
+      - type: archive
+        url: https://github.com/dagargo/elektroid/releases/download/2.4.1/elektroid-2.4.1.tar.gz
+        sha256: 5690754d4cd73309cb6d6af898643f9e27c7cdaebba12747e5616c8548755cf2
+  - name: elektroid.sh
+    buildsystem: simple
+    sources:
+      - type: script
+        dest-filename: elektroid.sh
+        commands:
+          - if test "$1" = "--cli"; then shift; exec elektroid-cli "$@"; fi
+          - exec elektroid "$@"
+    build-commands:
+      - install -t /app/bin/ elektroid.sh


### PR DESCRIPTION
As described in the README change, this allows you to build a bundled Flatpak application. On Fedora, that would be done like this:

    sudo dnf install flatpak-builder
    flatpak-builder --user --install flatpak/build flatpak/io.github.dagargo.Elektroid.yaml

Once installed, you can run it like:

    flatpak run io.github.dagargo.Elektroid

or for the CLI:

    flatpak run io.github.dagargo.Elektroid --cli info

or equivalently:

    flatpak run --command=elektroid-cli io.github.dagargo.Elektroid info

If this gets added to the repo, I think you would be able to [submit Elektroid to Flathub](https://github.com/flathub/flathub/wiki/App-Submission#how-to-submit-an-app) so that users can install it simply by running `flatpak install io.github.dagargo.Elektroid` (no need to download/clone anything and build from source). That might make it accessible to more users than the https://copr.fedorainfracloud.org/coprs/jwakely/elektroid/ packages I provide for Fedora and CentOS, but I've only lightly tested the flatpak on non-Fedora systems so far.