### PR TITLE
Add <releases> to appdata

### DIFF
--- a/res/elektroid.appdata.xml
+++ b/res/elektroid.appdata.xml
@@ -13,8 +13,17 @@
  </description>
  <launchable type="desktop-id">elektroid.desktop</launchable>
  <provides>
-​  <binary>elektroid</binary>
+  <binary>elektroid</binary>
  </provides>
+ <releases>
+  <release version="2.4.1" date="2023-02-10" />
+  <release version="2.3" date="2022-12-04" />
+  <release version="2.2" date="2022-11-20" />
+  <release version="2.1" date="2022-06-03" />
+  <release version="2.0" date="2022-01-12" />
+  <release version="1.4" date="2021-07-18" />
+  <release version="1.3" date="2021-02-07" />
+ </releases>
  <screenshots>
   <screenshot type="default">
    <image>https://screenshots.debian.net/screenshots/000/019/315/large.png</image>


### PR DESCRIPTION
Also remove stray non-ASCII zero-width space before <binary> element.

The [`<releases>` tag](https://freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html) is used to set the Version number of flatpak builds.
