### PR TITLE
Fix the name of the search button

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -386,9 +386,13 @@ msgstr "Actualitza els dispositius"
 msgid "Go to Parent Directory"
 msgstr "Ves al directori pare"
 
-#: res/gui.glade:1700 res/gui.glade:1721 res/gui.glade:1978 res/gui.glade:1999
+#: res/gui.glade:1700 res/gui.glade:1978
 msgid "Refresh Directory"
 msgstr "Actualitza el directori"
+
+#: res/gui.glade:1721 res/gui.glade:1999
+msgid "Search"
+msgstr ""
 
 #: res/gui.glade:1844 res/gui.glade:2165
 msgid "Size"

--- a/po/de.po
+++ b/po/de.po
@@ -387,9 +387,13 @@ msgstr "Aktualisiere Geräte"
 msgid "Go to Parent Directory"
 msgstr "Gehe zum Überverzeichnis"
 
-#: res/gui.glade:1700 res/gui.glade:1721 res/gui.glade:1978 res/gui.glade:1999
+#: res/gui.glade:1700 res/gui.glade:1978
 msgid "Refresh Directory"
 msgstr "Aktualisiere Verzeichnis"
+
+#: res/gui.glade:1721 res/gui.glade:1999
+msgid "Search"
+msgstr "Suche"
 
 #: res/gui.glade:1844 res/gui.glade:2165
 msgid "Size"

--- a/po/elektroid.pot
+++ b/po/elektroid.pot
@@ -386,8 +386,12 @@ msgstr ""
 msgid "Go to Parent Directory"
 msgstr ""
 
-#: res/gui.glade:1700 res/gui.glade:1721 res/gui.glade:1978 res/gui.glade:1999
+#: res/gui.glade:1700 res/gui.glade:1978
 msgid "Refresh Directory"
+msgstr ""
+
+#: res/gui.glade:1721 res/gui.glade:1999
+msgid "Search"
 msgstr ""
 
 #: res/gui.glade:1844 res/gui.glade:2165

--- a/po/en.po
+++ b/po/en.po
@@ -386,8 +386,12 @@ msgstr ""
 msgid "Go to Parent Directory"
 msgstr ""
 
-#: res/gui.glade:1700 res/gui.glade:1721 res/gui.glade:1978 res/gui.glade:1999
+#: res/gui.glade:1700 res/gui.glade:1978
 msgid "Refresh Directory"
+msgstr ""
+
+#: res/gui.glade:1721 res/gui.glade:1999
+msgid "Search"
 msgstr ""
 
 #: res/gui.glade:1844 res/gui.glade:2165

--- a/po/es.po
+++ b/po/es.po
@@ -386,9 +386,13 @@ msgstr "Actualizar dispositivos"
 msgid "Go to Parent Directory"
 msgstr "Ir al directorio padre"
 
-#: res/gui.glade:1700 res/gui.glade:1721 res/gui.glade:1978 res/gui.glade:1999
+#: res/gui.glade:1700 res/gui.glade:1978
 msgid "Refresh Directory"
 msgstr "Actualizar directorio"
+
+#: res/gui.glade:1721 res/gui.glade:1999
+msgid "Search"
+msgstr "Buscar"
 
 #: res/gui.glade:1844 res/gui.glade:2165
 msgid "Size"

--- a/po/fr.po
+++ b/po/fr.po
@@ -386,9 +386,13 @@ msgstr "Rafraîchir les périphériques"
 msgid "Go to Parent Directory"
 msgstr "Aller au répertoire parent"
 
-#: res/gui.glade:1700 res/gui.glade:1721 res/gui.glade:1978 res/gui.glade:1999
+#: res/gui.glade:1700 res/gui.glade:1978
 msgid "Refresh Directory"
 msgstr "Rafraîchir le répertoire"
+
+#: res/gui.glade:1721 res/gui.glade:1999
+msgid "Search"
+msgstr "Recherche"
 
 #: res/gui.glade:1844 res/gui.glade:2165
 msgid "Size"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -388,9 +388,13 @@ msgstr "Atualizar dispositivos"
 msgid "Go to Parent Directory"
 msgstr "Ir para o diretório pai"
 
-#: res/gui.glade:1700 res/gui.glade:1721 res/gui.glade:1978 res/gui.glade:1999
+#: res/gui.glade:1700 res/gui.glade:1978
 msgid "Refresh Directory"
 msgstr "Atualizar diretório"
+
+#: res/gui.glade:1721 res/gui.glade:1999
+msgid "Search"
+msgstr ""
 
 #: res/gui.glade:1844 res/gui.glade:2165
 msgid "Size"

--- a/res/gui.glade
+++ b/res/gui.glade
@@ -1714,11 +1714,11 @@ along with Elektroid.  If not, see <http://www.gnu.org/licenses/>.
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="remote_search_button">
-                                        <property name="name">remote_refresh_button</property>
+                                        <property name="name">remote_search_button</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">True</property>
-                                        <property name="tooltip-text" translatable="yes">Refresh Directory</property>
+                                        <property name="tooltip-text" translatable="yes">Search</property>
                                         <child>
                                           <object class="GtkImage">
                                             <property name="visible">True</property>
@@ -1992,11 +1992,11 @@ along with Elektroid.  If not, see <http://www.gnu.org/licenses/>.
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="local_search_button">
-                                        <property name="name">local_refresh_button</property>
+                                        <property name="name">local_search_button</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">True</property>
-                                        <property name="tooltip-text" translatable="yes">Refresh Directory</property>
+                                        <property name="tooltip-text" translatable="yes">Search</property>
                                         <child>
                                           <object class="GtkImage">
                                             <property name="visible">True</property>


### PR DESCRIPTION
This fixes the name/mouse over of the search button in the GUI.
It shows wrongly "refresh directory".