### PR TITLE
Fix error: implicit declaration of function ‘g_unlink’; did you mean ‘unlink’?

### DIFF
--- a/src/connectors/system.c
+++ b/src/connectors/system.c
@@ -27,7 +27,7 @@
 #include "local.h"
 #include "sample.h"
 #include "connectors/common.h"
-#include <sys/unistd.h>
+#include <unistd.h>
 
 struct system_iterator_data
 {

--- a/src/connectors/system.c
+++ b/src/connectors/system.c
@@ -27,6 +27,7 @@
 #include "local.h"
 #include "sample.h"
 #include "connectors/common.h"
+#include <sys/unistd.h>
 
 struct system_iterator_data
 {
@@ -128,7 +129,7 @@ system_delete (struct backend *backend, const gchar *path)
   else
     {
       debug_print (1, "Deleting local %s file...\n", path);
-      return g_unlink (path);
+      return unlink (path);
     }
 }
 

--- a/src/connectors/system.c
+++ b/src/connectors/system.c
@@ -20,6 +20,7 @@
 
 #include <errno.h>
 #include <glib/gi18n.h>
+#include <glib/gstdio.h>
 #if defined(__linux__)
 #include <sys/statvfs.h>
 #include <mntent.h>
@@ -27,7 +28,6 @@
 #include "local.h"
 #include "sample.h"
 #include "connectors/common.h"
-#include <unistd.h>
 
 struct system_iterator_data
 {
@@ -129,7 +129,7 @@ system_delete (struct backend *backend, const gchar *path)
   else
     {
       debug_print (1, "Deleting local %s file...\n", path);
-      return unlink (path);
+      return g_unlink (path);
     }
 }
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -23,6 +23,7 @@
 #include "editor.h"
 #include "sample.h"
 #include "connectors/system.h"
+#include <sys/unistd.h>
 
 #define EDITOR_OP_NONE 0
 #define EDITOR_OP_SELECT 1
@@ -1169,7 +1170,7 @@ editor_save_to_remote (struct editor *editor, gchar *name, GByteArray *sample)
   err = editor->browser->fs_ops->upload (editor->browser->backend, name,
 					 tmp_sample, &editor->audio.control);
 cleanup:
-  g_unlink (tmp_file);
+  unlink (tmp_file);
   g_byte_array_free (tmp_sample, TRUE);
 end:
   g_free (tmp_file);

--- a/src/editor.c
+++ b/src/editor.c
@@ -23,7 +23,7 @@
 #include "editor.h"
 #include "sample.h"
 #include "connectors/system.h"
-#include <sys/unistd.h>
+#include <unistd.h>
 
 #define EDITOR_OP_NONE 0
 #define EDITOR_OP_SELECT 1

--- a/src/editor.c
+++ b/src/editor.c
@@ -20,10 +20,10 @@
 
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
+#include <glib/gstdio.h>
 #include "editor.h"
 #include "sample.h"
 #include "connectors/system.h"
-#include <unistd.h>
 
 #define EDITOR_OP_NONE 0
 #define EDITOR_OP_SELECT 1
@@ -1170,7 +1170,7 @@ editor_save_to_remote (struct editor *editor, gchar *name, GByteArray *sample)
   err = editor->browser->fs_ops->upload (editor->browser->backend, name,
 					 tmp_sample, &editor->audio.control);
 cleanup:
-  unlink (tmp_file);
+  g_unlink (tmp_file);
   g_byte_array_free (tmp_sample, TRUE);
 end:
   g_free (tmp_file);


### PR DESCRIPTION
Hi,

since we use dpkg 1.22.6 in debian, we have the function -Werror=implicit-function-declaration enabled.
This causes the current elektroid build to fail with:

> gcc -DHAVE_CONFIG_H -I. -I..  -Wall -O3 -DDATADIR='"/usr/share/elektroid"' -DLOCALEDIR='"/usr/share/locale"' -Wdate-time -D_FORTIFY_SOURCE=2 -I../src `/usr/bin/pkg-config --cflags alsa glib-2.0 zlib json-glib-1.0 libzip` -I/usr/include/opus -I/usr/include/x86_64-linux-gnu   -D_GNU_SOURCE -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -c -o elektroid_cli-connector.o `test -f 'connector.c' || echo './'`connector.c
> editor.c: In function ‘editor_save_to_remote’:
> editor.c:1166:3: error: implicit declaration of function ‘g_unlink’; did you mean ‘unlink’? [-Werror=implicit-function-declaration]
>  1166 |   g_unlink (tmp_file);
>       |   ^~~~~~~~
>       |   unlink

Here is the debian bug with some more info: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1066566

This PR fixes the build, by setting unlink instead of g_unlink.