### PR TITLE
Fix keep keyboard focus on treeview when changing directory

### DIFF
--- a/src/browser.c
+++ b/src/browser.c
@@ -486,6 +486,7 @@ browser_load_dir_runner_update_ui (gpointer data)
 	  gtk_tree_view_scroll_to_cell (browser->view, first, NULL, FALSE, 0,
 					0);
 	  gtk_tree_path_free (first);
+	  gtk_widget_grab_focus (GTK_WIDGET (browser->view));
 	}
       //If editor.audio.path is empty is a recording buffer.
       if (editor.browser == browser && editor.audio.path)


### PR DESCRIPTION
It was bugging me that every time I entered a directory the keyboard focus jumped to the format/sample rate dropdown instead of letting me continue navigating using up/down.

Curiously it seems running `indent` (2.2.12) without any parameters (as suggested in an older issue) introduces changes to current formatting (spaces after `*` in function parameters) and running with `--pointer-align-right` does not seem to help.
