### PR TITLE
Adjust docs to changed list command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ There are filesystem commands and non-filesystem commands. The former have the f
 
 These are the available commands:
 
-* `ls` or `list`
+* `ld` or `list-devices`
 * `mkdir` (behave as `mkdir -p`)
 * `rmdir` or `rm` (both behave as `rm -rf`)
 * `mv` (in slot mode, the second path is just the name of the file)


### PR DESCRIPTION
The list command has changed
I figured that below in the command examples ld is used, so added this adjustment here