### PR TITLE
Add folder size calculation and column sorting

### DIFF
--- a/res/elektroid.ui
+++ b/res/elektroid.ui
@@ -4155,6 +4155,86 @@ on remote</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="valign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
+                    <child>
+                      <!-- n-columns=2 n-rows=2 -->
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">12</property>
+                        <property name="hexpand">True</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">6</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Calculate folder sizes</property>
+                            <property name="wrap">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="prefs_window_show_folder_sizes_switch">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="hexpand">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Slows down browsing, especially on connected devices.</property>
+                            <property name="wrap">True</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label">Browser</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
             </child>
             <child type="tab">

--- a/src/browser.c
+++ b/src/browser.c
@@ -185,6 +185,30 @@ browser_sort_by_name (GtkTreeModel *model,
 }
 
 static gint
+browser_sort_by_size (GtkTreeModel *model,
+		      GtkTreeIter *a, GtkTreeIter *b, gpointer data)
+{
+  struct item itema;
+  struct item itemb;
+
+  browser_set_item (model, a, &itema);
+  browser_set_item (model, b, &itemb);
+
+  if (itema.type == itemb.type)
+    {
+      if (itema.size < itemb.size)
+	return -1;
+      if (itema.size > itemb.size)
+	return 1;
+      return 0;
+    }
+  else
+    {
+      return itema.type > itemb.type;
+    }
+}
+
+static gint
 browser_set_selected_row_iter (struct browser *browser, GtkTreeIter *iter)
 {
   gint index, *indices;
@@ -434,6 +458,7 @@ void
 browser_refresh (GtkWidget *object, gpointer data)
 {
   struct browser *browser = data;
+  g_hash_table_remove_all (browser->folder_size_cache);
   browser_load_dir (browser);
 }
 
@@ -1285,14 +1310,79 @@ cleanup:
   item_sample_info_clear (&iter->item, browser);
 }
 
+static gint64
+browser_sum_dir_size (struct browser *browser, const gchar *dir,
+		      const gchar **extensions)
+{
+  gint64 total = 0;
+  gboolean loading;
+  struct item_iterator child_iter;
+  enum path_type type = backend_get_path_type (browser->backend);
+
+  if (browser->fs_ops->readdir (browser->backend, &child_iter, dir,
+				extensions))
+    return 0;
+
+  while (!item_iterator_next (&child_iter))
+    {
+      g_mutex_lock (&browser->mutex);
+      loading = browser->loading;
+      g_mutex_unlock (&browser->mutex);
+
+      if (!loading
+	  || !preferences_get_boolean (PREF_KEY_SHOW_FOLDER_SIZES))
+	break;
+
+      if (child_iter.item.type == ITEM_TYPE_DIR)
+	{
+	  gchar *child_dir = path_chain (type, dir, child_iter.item.name);
+	  total += browser_sum_dir_size (browser, child_dir, extensions);
+	  g_free (child_dir);
+	}
+      else
+	{
+	  total += child_iter.item.size;
+	}
+    }
+
+  item_iterator_free (&child_iter);
+  return total;
+}
+
 static void
 browser_iterate_dir (struct browser *browser, struct item_iterator *iter,
 		     const gchar *icon)
 {
   gboolean loading = TRUE;
+  const gchar **exts = browser_get_exts (browser);
+  enum path_type type = backend_get_path_type (browser->backend);
 
   while (loading && !item_iterator_next (iter))
     {
+      if (iter->item.type == ITEM_TYPE_DIR && iter->item.size <= 0
+	  && browser->fs_ops->readdir
+	  && preferences_get_boolean (PREF_KEY_SHOW_FOLDER_SIZES))
+	{
+	  gchar *child_dir = path_chain (type, browser->dir,
+					 iter->item.name);
+	  gint64 *cached = g_hash_table_lookup (browser->folder_size_cache,
+						child_dir);
+	  if (cached)
+	    {
+	      iter->item.size = *cached;
+	      g_free (child_dir);
+	    }
+	  else
+	    {
+	      iter->item.size =
+		browser_sum_dir_size (browser, child_dir, exts);
+	      gint64 *size_val = g_new (gint64, 1);
+	      *size_val = iter->item.size;
+	      g_hash_table_insert (browser->folder_size_cache,
+				   child_dir, size_val);
+	    }
+	}
+
       browser_iterate_dir_add (browser, iter, icon, &iter->item,
 			       strdup (iter->item.name));
 
@@ -1416,9 +1506,9 @@ browser_load_dir_runner (gpointer data)
   g_idle_add (browser_load_dir_runner_show_spinner_and_lock_browser, browser);
   err = browser->fs_ops->readdir (browser->backend, &iter, browser->dir,
 				  exts);
-  g_idle_add (browser_load_dir_runner_hide_spinner, browser);
   if (err)
     {
+      g_idle_add (browser_load_dir_runner_hide_spinner, browser);
       error_print ("Error while opening '%s' dir", browser->dir);
       goto end;
     }
@@ -1439,6 +1529,7 @@ browser_load_dir_runner (gpointer data)
       browser_iterate_dir (browser, &iter, icon);
     }
 
+  g_idle_add (browser_load_dir_runner_hide_spinner, browser);
   item_iterator_free (&iter);
 
 end:
@@ -1506,15 +1597,30 @@ browser_update_fs_sorting_options (struct browser *browser)
       gtk_tree_sortable_set_sort_func (sortable,
 				       BROWSER_LIST_STORE_NAME_FIELD,
 				       browser_sort_by_name, NULL, NULL);
+      gtk_tree_sortable_set_sort_func (sortable,
+				       BROWSER_LIST_STORE_SIZE_FIELD,
+				       browser_sort_by_size, NULL, NULL);
       gtk_tree_sortable_set_sort_column_id (sortable,
 					    BROWSER_LIST_STORE_NAME_FIELD,
-					    GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID);
+					    GTK_SORT_ASCENDING);
+
+      gtk_tree_view_column_set_sort_column_id (browser->tree_view_name_column,
+					       BROWSER_LIST_STORE_NAME_FIELD);
+      if (browser->tree_view_size_column)
+	gtk_tree_view_column_set_sort_column_id
+	  (browser->tree_view_size_column, BROWSER_LIST_STORE_SIZE_FIELD);
     }
   else
     {
       gtk_tree_sortable_set_sort_column_id (sortable,
 					    GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
 					    GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID);
+
+      gtk_tree_view_column_set_sort_column_id (browser->tree_view_name_column,
+					       -1);
+      if (browser->tree_view_size_column)
+	gtk_tree_view_column_set_sort_column_id
+	  (browser->tree_view_size_column, -1);
     }
 }
 
@@ -2280,6 +2386,7 @@ browser_destroy (struct browser *browser)
 
   notifier_destroy (browser->notifier);
   g_slist_free (browser->sensitive_widgets);
+  g_hash_table_destroy (browser->folder_size_cache);
 }
 
 void
@@ -2324,6 +2431,7 @@ browser_reset (struct browser *browser)
   browser->dir = NULL;
   browser->pending_req = 0;
   browser_clear (browser);
+  g_hash_table_remove_all (browser->folder_size_cache);
 }
 
 static void
@@ -2632,6 +2740,8 @@ browser_init (struct browser *browser)
 		     GDK_ACTION_COPY | GDK_ACTION_MOVE);
 
   browser->reload_item_in_editor = TRUE;
+  browser->folder_size_cache =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   notifier_init (&browser->notifier, browser);
 }
 
@@ -2740,7 +2850,9 @@ browser_local_init (struct browser *browser, GtkBuilder *builder)
 
   browser->tree_view_id_column = NULL;
   browser->tree_view_slot_column = NULL;
-  browser->tree_view_size_column = NULL;
+  browser->tree_view_size_column =
+    GTK_TREE_VIEW_COLUMN (gtk_builder_get_object
+			  (builder, "local_tree_view_size_column"));
 
   g_signal_connect (browser->popover_transfer_button, "clicked",
 		    G_CALLBACK (elektroid_add_upload_tasks), NULL);

--- a/src/browser.h
+++ b/src/browser.h
@@ -125,6 +125,7 @@ struct browser
   GtkTreeViewColumn *tree_view_id_column;
   GtkTreeViewColumn *tree_view_slot_column;
   GtkTreeViewColumn *tree_view_size_column;
+  GHashTable *folder_size_cache;
 };
 
 struct browser_drag_data_received_data

--- a/src/connectors/system.c
+++ b/src/connectors/system.c
@@ -27,6 +27,7 @@
 #include <mntent.h>
 #endif
 #include "local.h"
+#include "preferences.h"
 #include "sample.h"
 #include "connectors/common.h"
 
@@ -156,8 +157,33 @@ system_next_dentry (struct item_iterator *iter, gboolean sample_info)
 	{
 	  item_set_name (&iter->item, "%s", name);
 	  iter->item.type = type;
-	  iter->item.size = g_file_info_get_size (info);
 	  iter->item.id = -1;
+
+	  if (type == ITEM_TYPE_DIR
+	      && preferences_get_boolean (PREF_KEY_SHOW_FOLDER_SIZES))
+	    {
+	      guint64 disk_usage;
+	      if (g_file_measure_disk_usage (file,
+					     G_FILE_MEASURE_NONE,
+					     NULL, NULL, NULL,
+					     &disk_usage, NULL, NULL,
+					     NULL))
+		{
+		  iter->item.size = (gint64) disk_usage;
+		}
+	      else
+		{
+		  iter->item.size = -1;
+		}
+	    }
+	  else if (type == ITEM_TYPE_FILE)
+	    {
+	      iter->item.size = g_file_info_get_size (info);
+	    }
+	  else
+	    {
+	      iter->item.size = 0;
+	    }
 
 	  if (item_iterator_is_dir_or_matches_exts (iter, data->extensions))
 	    {

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -39,6 +39,7 @@
 #define PREF_KEY_TAGS_GENRES "tagsGenres"
 #define PREF_KEY_TAGS_OBJECTIVE_CHARS "tagsObjectiveCharacteristics"
 #define PREF_KEY_TAGS_SUBJECTIVE_CHARS "tagsSubjectiveCharacteristics"
+#define PREF_KEY_SHOW_FOLDER_SIZES "showFolderSizes"
 
 enum preference_type
 {

--- a/src/preferences_window.c
+++ b/src/preferences_window.c
@@ -36,6 +36,7 @@ static GtkWidget *tags_instruments_text_view;
 static GtkWidget *tags_genres_text_view;
 static GtkWidget *tags_subj_chars_text_view;
 static GtkWidget *tags_obj_chars_text_view;
+static GtkWidget *show_folder_sizes_switch;
 static GtkWidget *save_button;
 static GtkWidget *cancel_button;
 
@@ -89,6 +90,8 @@ preferences_window_save (GtkWidget *object, gpointer data)
   preferences_set_boolean (PREF_KEY_STOP_DEVICE_WHEN_CONNECTING, b);
   b = gtk_switch_get_active (GTK_SWITCH (elektron_load_sound_tags_switch));
   preferences_set_boolean (PREF_KEY_ELEKTRON_LOAD_SOUND_TAGS, b);
+  b = gtk_switch_get_active (GTK_SWITCH (show_folder_sizes_switch));
+  preferences_set_boolean (PREF_KEY_SHOW_FOLDER_SIZES, b);
 
   i = gtk_combo_box_get_active (GTK_COMBO_BOX (audio_buffer_length_combo));
 
@@ -160,6 +163,8 @@ preferences_window_open ()
   gtk_switch_set_active (GTK_SWITCH (stop_device_when_connecting_switch), b);
   b = preferences_get_boolean (PREF_KEY_ELEKTRON_LOAD_SOUND_TAGS);
   gtk_switch_set_active (GTK_SWITCH (elektron_load_sound_tags_switch), b);
+  b = preferences_get_boolean (PREF_KEY_SHOW_FOLDER_SIZES);
+  gtk_switch_set_active (GTK_SWITCH (show_folder_sizes_switch), b);
 
   buffer_len = preferences_get_int (PREF_KEY_AUDIO_BUFFER_LEN);
 
@@ -227,6 +232,9 @@ preferences_window_init (GtkBuilder *builder)
   elektron_load_sound_tags_switch =
     GTK_WIDGET (gtk_builder_get_object
 		(builder, "prefs_window_elektron_load_sound_tags_switch"));
+  show_folder_sizes_switch =
+    GTK_WIDGET (gtk_builder_get_object
+		(builder, "prefs_window_show_folder_sizes_switch"));
 
   tags_structures_text_view =
     GTK_WIDGET (gtk_builder_get_object

--- a/src/regpref.c
+++ b/src/regpref.c
@@ -216,6 +216,12 @@ const struct preference PREF_TAGS_SUBJECTIVE_CHARS = {
   .get_value = regpref_get_tags_subjective
 };
 
+static const struct preference PREF_SHOW_FOLDER_SIZES = {
+  .key = PREF_KEY_SHOW_FOLDER_SIZES,
+  .type = PREFERENCE_TYPE_BOOLEAN,
+  .get_value = preferences_get_boolean_value_false
+};
+
 void
 regpref_register ()
 {
@@ -226,7 +232,8 @@ regpref_register ()
 	       &PREF_SHOW_PLAYBACK_CURSOR, &PREF_STOP_DEVICE_WHEN_CONNECTING,
 	       &PREF_ELEKTRON_LOAD_SOUND_TAGS, &PREF_TAGS_STRUCTURES,
 	       &PREF_TAGS_INSTRUMENTS, &PREF_TAGS_GENRES,
-	       &PREF_TAGS_OBJECTIVE_CHARS, &PREF_TAGS_SUBJECTIVE_CHARS, NULL);
+	       &PREF_TAGS_OBJECTIVE_CHARS, &PREF_TAGS_SUBJECTIVE_CHARS,
+	       &PREF_SHOW_FOLDER_SIZES, NULL);
 }
 
 void


### PR DESCRIPTION
## Summary
- Add clickable column headers for sorting by name and size in file browsers
- Calculate folder sizes for both local filesystem (via `g_file_measure_disk_usage`) and connected devices (recursive `readdir`)
- Add in-memory cache for folder sizes, cleared on refresh or device reconnect
- Add preference toggle (off by default) with warning about performance impact
- Cancel size calculation promptly when preference is toggled off mid-browse

## Context
Folder sizes were not shown for directories, and columns were not sortable. This adds both features behind an opt-in preference since folder size calculation is slow, especially on connected devices.