### PR TITLE
fix: add missing format string argument

### DIFF
--- a/src/elektroid.c
+++ b/src/elektroid.c
@@ -202,7 +202,7 @@ elektroid_ask_user_to_continue_show (gpointer user_data)
 
   data->dialog = gtk_message_dialog_new (main_window, GTK_DIALOG_MODAL,
 					 GTK_MESSAGE_WARNING,
-					 GTK_BUTTONS_NONE, data->msg);
+					 GTK_BUTTONS_NONE, "%s", data->msg);
   gtk_dialog_add_buttons (GTK_DIALOG (data->dialog), _("_Cancel"),
 			  GTK_RESPONSE_CANCEL, _("_Continue"),
 			  GTK_RESPONSE_ACCEPT, NULL);


### PR DESCRIPTION
Compilation fails when using `-Werror=format-security` compiler flag:

```
elektroid.c: In function 'elektroid_ask_user_to_continue_show':
elektroid.c:205:42: error: format not a string literal and no format arguments [-Werror=format-security]
  205 |                                          GTK_BUTTONS_NONE, data->msg);
      |                                          ^~~~~~~~~~~~~~~~
```

The error is caused by a call to `gtk_message_dialog_new`, in which the format string argument is not a string literal and no format arguments follow.